### PR TITLE
parliament performance link  is updated 

### DIFF
--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -121,7 +121,7 @@ export default function Header({ data, setIndex, selected }) {
     },
     {
       title: 'Parliament Performance',
-      pageUrl: '/parliament-performance',
+      pageUrl: '/parliament-performance/lok-sabha-performance',
     },
     {
       title: 'MPs Parliament Performance',


### PR DESCRIPTION
header link for /parliament-performance is updated to default /parliament-performance/lok-sabha-performance